### PR TITLE
Fix site title

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta name="generator" content="jemdoc, see http://jemdoc.jaboc.net/" />
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <link rel="stylesheet" href="jemdoc.css" type="text/css" />
-<title>Lin Xiao <span lang="zh" xml:lang="zh">  肖林 </span></title>
+<title>Lin Xiao  肖林</title>
 </head>
 <body>
 <table summary="Table for page layout." id="tlayout">


### PR DESCRIPTION
Fixed the site title. This is how it looks before the change:
<img width="229" alt="image" src="https://user-images.githubusercontent.com/71658949/208550870-61eb6a48-ada9-43fa-9d38-16e99f9d5524.png">

And after:
<img width="120" alt="image" src="https://user-images.githubusercontent.com/71658949/208550935-ac3c9416-bae0-46e6-8261-6254d059f6c4.png">